### PR TITLE
Fix SS6 captcha validation logic, bump PHPUnit, add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ci:
+    name: CI
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions: {}
-
 jobs:
   ci:
     name: CI
-    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v1
+    # Do not run if this is a pull-request from same repo i.e. not a fork repo
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
+    uses: silverstripe/gha-ci/.github/workflows/ci.yml@v2

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "silverstripe/spamprotection": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "silverstripe/spamprotection": "^5"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^11.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Forms/TurnstileCaptchaField.php
+++ b/src/Forms/TurnstileCaptchaField.php
@@ -86,7 +86,11 @@ class TurnstileCaptchaField extends FormField
         $secretKey = $this->getSecretKey();
 
         if (empty($siteKey) || empty($secretKey)) {
-            user_error('You must configure site_key and secret_key, you can retrieve these at https://developers.cloudflare.com/turnstile/', E_USER_ERROR);
+            user_error(
+                'You must configure site_key and secret_key, you can retrieve these at '
+                    . 'https://developers.cloudflare.com/turnstile/',
+                E_USER_ERROR
+            );
         }
 
         Requirements::javascript(
@@ -144,7 +148,6 @@ class TurnstileCaptchaField extends FormField
                 if (is_array($responseBody)) {
                     $this->verifyResponse = $responseBody;
                 }
-
             } catch (GuzzleException $e) {
                 $logger = Injector::inst()->get(LoggerInterface::class);
                 $logger->error($e->getMessage());

--- a/src/Forms/TurnstileCaptchaField.php
+++ b/src/Forms/TurnstileCaptchaField.php
@@ -114,16 +114,19 @@ class TurnstileCaptchaField extends FormField
             $captchaResponse = $request->requestVar('cf-turnstile-response');
 
             if (!isset($captchaResponse)) {
-               $result->addFieldError(
+                $result->addFieldError(
                     $this->name,
                     _t(
                         'Terraformers\\TurnstileCaptcha\\Forms\\TurnstileCaptchaField.NOSCRIPT',
                         'if you do not see the captcha you must enable JavaScript'
                     )
                 );
+
+                return;
             }
 
             $client = $this->httpClient->getClient();
+
             try {
                 $response = $client->request(
                     'POST',
@@ -152,12 +155,11 @@ class TurnstileCaptchaField extends FormField
                         'Turnstile Captcha Field could not be validated'
                     )
                 );
+
+                return;
             }
 
-            if (
-                isset($response) && $response->getStatusCode() !== 200 ||
-                !$this->verifyResponse['success']
-            ) {
+            if ($response->getStatusCode() !== 200 || !$this->verifyResponse['success']) {
                 $result->addFieldError(
                     $this->name,
                     _t(

--- a/tests/TurnstileCaptchaFieldTest.php
+++ b/tests/TurnstileCaptchaFieldTest.php
@@ -18,12 +18,11 @@ use Terraformers\TurnstileCaptcha\Http\HttpClient;
 
 class TurnstileCaptchaFieldTest extends SapphireTest
 {
-
     protected $usesDatabase = false;
 
     public static function setUpBeforeClass(): void
-    {  
-        // workaround to disable test database connection 
+    {
+        // workaround to disable test database connection
         // @see https://github.com/silverstripe/silverstripe-framework/issues/10849
         parent::setUpBeforeClass();
         $states = static::$state->getStates();
@@ -31,7 +30,6 @@ class TurnstileCaptchaFieldTest extends SapphireTest
         static::$state->setStates($states);
 
         static::$tempDB = null;
-
     }
 
     /**
@@ -62,7 +60,7 @@ class TurnstileCaptchaFieldTest extends SapphireTest
         {
             public function __construct(?Client $client = null)
             {
-        
+
                 // Create a Mock Handler with success & fail response data
                 $mock = new MockHandler([
                     // first request passes
@@ -84,30 +82,29 @@ class TurnstileCaptchaFieldTest extends SapphireTest
                 ]);
                 $handleStack = HandlerStack::create($mock);
                 $client = new Client(['handler' => $handleStack]);
-                
+
                 $this->client = $client;
             }
-        
         };
 
         Injector::inst()->registerService($testClient, HttpClient::class);
 
-        $request = new HTTPRequest('POST', '/', [], ['cf-turnstile-response'=> 'abcd']);
+        $request = new HTTPRequest('POST', '/', [], ['cf-turnstile-response' => 'abcd']);
         Controller::curr()->setRequest($request);
-        
+
         $turnstileCaptchField = TurnstileCaptchaField::create('turnstileField');
         $result = $turnstileCaptchField->validate();
         // first request should pass validation
         $this->assertTrue($result->isValid());
         $this->assertEmpty($result->getMessages());
-        
+
         // second should fail
         $result = $turnstileCaptchField->validate();
         $this->assertFalse($result->isValid());
         $errors = $result->getMessages();
 
         $this->assertEquals('Captcha could not be validated', $errors[0]['message']);
-        
+
         // third should fail gracefully (error)
         $result = $turnstileCaptchField->validate();
         $this->assertFalse($result->isValid());
@@ -115,5 +112,4 @@ class TurnstileCaptchaFieldTest extends SapphireTest
 
         $this->assertEquals('Captcha could not be validated', $errors[0]['message']);
     }
-
 }

--- a/tests/TurnstileCaptchaFieldTest.php
+++ b/tests/TurnstileCaptchaFieldTest.php
@@ -13,8 +13,6 @@ use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
 use SilverStripe\Forms\Form;
-use SilverStripe\Forms\Validation\RequiredFieldsValidator;
-use SilverStripe\Forms\Validator;
 use Terraformers\TurnstileCaptcha\Forms\TurnstileCaptchaField;
 use Terraformers\TurnstileCaptcha\Http\HttpClient;
 
@@ -111,7 +109,7 @@ class TurnstileCaptchaFieldTest extends SapphireTest
         $this->assertEquals('Captcha could not be validated', $errors[0]['message']);
         
         // third should fail gracefully (error)
-        $validation = $turnstileCaptchField->validate();
+        $result = $turnstileCaptchField->validate();
         $this->assertFalse($result->isValid());
         $errors = $result->getMessages();
 


### PR DESCRIPTION
Follow-up to #15 (now merged) addressing the review findings, plus tooling.

## Validation logic fixes (`src/Forms/TurnstileCaptchaField.php`)
- **Restore the missing-captcha early return.** #15 dropped the `return` after the `NOSCRIPT` error, so a JS-disabled submission fell through and still fired a `siteverify` request with `response => null`, adding a second `VALIDATE_ERROR`. It now returns immediately.
- **Return after `GuzzleException`.** The catch added an error then fell through to the post-request `if`. Because `&&` binds tighter than `||`, the trailing `|| !verifyResponse['success']` was always true on a transport failure, adding a duplicate error. The exception path now returns, and the post-request condition no longer needs the `isset($response)` guard.

## Test fix (`tests/TurnstileCaptchaFieldTest.php`)
- The third block stored the result in `$validation` but asserted on `$result` — i.e. the second call's result — so the error/500 path was never actually tested. Now assigns to `$result`.
- Removed the unused `RequiredFieldsValidator` and `Validator` imports.

## Tooling
- Bumped `phpunit/phpunit` to `^11.5` — `^9.5` is incompatible with Silverstripe 6's PHPUnit 11-based `SapphireTest`.
- Added `.github/workflows/ci.yml` using the `silverstripe/gha-ci` reusable workflow (lint, PHPUnit, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)